### PR TITLE
#24: display route params types names (closes #24)

### DIFF
--- a/src/metarpheusTcomb.js
+++ b/src/metarpheusTcomb.js
@@ -74,8 +74,8 @@ export default function metarpheusTcomb({
       ).join(', ');
     })()}].join('/'),
     routeParamTypes: [${route.filter(ParamSegment.is).map(({
-      routeParam: { tpe }
-    }) => genTypeM(tpe)).join(', ')}],
+      routeParam: { name, tpe }
+    }) => `{ ${name}: ${genTypeM(tpe)} }`).join(', ')}],
     params: {
       ${generateParams(queryParams)}
     }${body ? `,

--- a/test/fixtures/api-out.js
+++ b/test/fixtures/api-out.js
@@ -184,7 +184,7 @@ export default [
     authenticated: true,
     returnType: m.Package,
     route: (...routeParams) => ['campings', routeParams[0]].join('/'),
-    routeParamTypes: [m.LabOnlineId/*Id[m.Package]*/],
+    routeParamTypes: [{ undefined: m.LabOnlineId/*Id[m.Package]*/ }],
     params: {
       
     }
@@ -211,7 +211,7 @@ export default [
     authenticated: true,
     returnType: m.Package,
     route: (...routeParams) => ['campings', routeParams[0]].join('/'),
-    routeParamTypes: [t.Number],
+    routeParamTypes: [{ id: t.Number }],
     params: {
       
     }

--- a/test/fixtures/api-out.js
+++ b/test/fixtures/api-out.js
@@ -177,19 +177,6 @@ export default [
     body: m.Package
   },
 
-  // GET /campings/ : get a camping by typed id
-  {
-    method: 'get',
-    name: ['campingController', 'getByTypedId'],
-    authenticated: true,
-    returnType: m.Package,
-    route: (...routeParams) => ['campings', routeParams[0]].join('/'),
-    routeParamTypes: [{ undefined: m.LabOnlineId/*Id[m.Package]*/ }],
-    params: {
-      
-    }
-  },
-
   // GET /campings/by_query : get multiple campings by params with case class
   {
     method: 'get',
@@ -212,6 +199,19 @@ export default [
     returnType: m.Package,
     route: (...routeParams) => ['campings', routeParams[0]].join('/'),
     routeParamTypes: [{ id: t.Number }],
+    params: {
+      
+    }
+  },
+
+  // GET /campings/ : get a camping by typed id
+  {
+    method: 'get',
+    name: ['campingController', 'getByTypedId'],
+    authenticated: true,
+    returnType: m.Package,
+    route: (...routeParams) => ['campings', routeParams[0]].join('/'),
+    routeParamTypes: [{ id: m.LabOnlineId/*Id[m.Package]*/ }],
     params: {
       
     }

--- a/test/fixtures/metarpheus-interm-rep.json
+++ b/test/fixtures/metarpheus-interm-rep.json
@@ -1218,6 +1218,7 @@
       "str" : "campings"
     }, {
       "routeParam" : {
+        "name": "id",
         "tpe" : {
           "name" : "Id",
           "args" : [ {


### PR DESCRIPTION
Closes #24

see also https://github.com/buildo/metarpheus-js-http-api/pull/27